### PR TITLE
IMR Calculation Update

### DIFF
--- a/+SimplusGT/+Modal/AppModalAnalysis.m
+++ b/+SimplusGT/+Modal/AppModalAnalysis.m
@@ -1,7 +1,7 @@
 % Matlab app of participation analysis of layers 1 and 2.
 
 % Author(s): Yue Zhu
-% Modified by: Yitong Li
+% Modified by: Yitong Li, George Zhang
 
 function [AppMdResults,MdDataSave]=AppModalAnalysis(ModeSelect)
 
@@ -56,16 +56,15 @@ for modei=1:ModeSelNum
     for k=1:length(ApparatusType)
         if ApparatusType{k} <= 89 % Ac apparatus
             IMR.Type(count) = ApparatusType{k};
-            % conj(sum(dot(A,B'))) = A(1,1)*B(1,1) + A(1,2)*B(2,1) + A(2,1)*B(1,2) + A(2,2)*B(2,2)
-            IMR.IMRVal(count) = SigmaMag/abs( -1 * conj(sum( dot(Residue{k},ZmVal{k}' )) ) ) ;
+            IMR.IMRVal(count) = SigmaMag/norm(Residue{k},"fro")*norm(ZmVal{k},"fro");
             count = count+1;
         elseif ApparatusType{k} >= 1000 && ApparatusType{k} <= 1089 % Dc apparatus
             IMR.Type(count) = ApparatusType{k};
-            IMR.IMRVal(count) = SigmaMag/abs( -1 * conj(sum( dot(Residue{k},ZmVal{k}' )) ) ) ;
+            IMR.IMRVal(count) = SigmaMag/norm(Residue{k},"fro")*norm(ZmVal{k},"fro");
             count = count+1;
         elseif ApparatusType{k} >= 2000 && ApparatusType{k} <= 2009 % Interlink apparatus
             IMR.Type(count) = ApparatusType{k};
-            IMR.IMRVal(count) = SigmaMag/abs( -1 * conj(sum( dot(Residue{k},ZmVal{k}' )) ) ) ;
+            IMR.IMRVal(count) = SigmaMag/norm(Residue{k},"fro")*norm(ZmVal{k},"fro");
             count = count+1;
         elseif  ApparatusType{k} == 90 || ApparatusType{k} == 1090   % infinite bus: let IMR=inf
             IMR.Type(count) = ApparatusType{k};

--- a/+SimplusGT/+Modal/SSCal.m
+++ b/+SimplusGT/+Modal/SSCal.m
@@ -2,7 +2,7 @@
 % apparatuses the user selected.
 %
 % Author(s): Yue Zhu
-% Modifed by: Yitong Li, Qipeng Zheng
+% Modifed by: Yitong Li, Qipeng Zheng, George Zhang
 
 function [Mode,ResidueAll,ZmValAll]=...
     SSCal(GminSS, N_Apparatus, ApparatusType, ModeSelect, GmDSS_Cell, ApparatusInputStr, ApparatusOutputStr)
@@ -26,33 +26,13 @@ for modei=1:ModeSelNum
     pin=1;
     pout=1;
     for k =1: N_Apparatus
-
         ZmValAll{modei}{k} = SimplusGT.Modal.ApparatusImpedanceCal(GmDSS_Cell{k}, lambda, ApparatusType{k});
-
         if ApparatusType{k} <= 89  % Ac apparatus
-            % Using the matrix format of ResidueAll{modei}(k) should be
-            % better, please change it later.
-            ResidueAll{modei}{k}(1,1)=C(pout,:) * Phi(:,ModeSel) * Psi(ModeSel,:) * B(:,pin);
-            ResidueAll{modei}{k}(1,2)=C(pout,:) * Phi(:,ModeSel) * Psi(ModeSel,:) * B(:,pin+1);
-            ResidueAll{modei}{k}(2,1)=C(pout+1,:) * Phi(:,ModeSel) * Psi(ModeSel,:) * B(:,pin);
-            ResidueAll{modei}{k}(2,2)=C(pout+1,:) * Phi(:,ModeSel) * Psi(ModeSel,:) * B(:,pin+1);           
-            
+            ResidueAll{modei}{k}=C(pout:pout+1,:) * Phi(:,ModeSel) * Psi(ModeSel,:) * B(:,pin:pin+1);
         elseif ApparatusType{k} >= 1000 && ApparatusType{k} <= 1089 % Dc apparatuses
-            ResidueAll{modei}{k}(1,1)=C(pout,:) * Phi(:,ModeSel) * Psi(ModeSel,:) * B(:,pin);
-
+            ResidueAll{modei}{k}=C(pout,:) * Phi(:,ModeSel) * Psi(ModeSel,:) * B(:,pin);
         elseif ApparatusType{k} >= 2000 && ApparatusType{k} <= 2009 % Interlink apparatuses
-
-            ResidueAll{modei}{k}(1,1)=C(pout,:) * Phi(:,ModeSel) * Psi(ModeSel,:) * B(:,pin);
-            ResidueAll{modei}{k}(1,2)=C(pout,:) * Phi(:,ModeSel) * Psi(ModeSel,:) * B(:,pin+1);
-            ResidueAll{modei}{k}(2,1)=C(pout+1,:) * Phi(:,ModeSel) * Psi(ModeSel,:) * B(:,pin);
-            ResidueAll{modei}{k}(2,2)=C(pout+1,:) * Phi(:,ModeSel) * Psi(ModeSel,:) * B(:,pin+1); 
-
-            ResidueAll{modei}{k}(1,3)=C(pout,:) * Phi(:,ModeSel) * Psi(ModeSel,:) * B(:,pin+2);
-            ResidueAll{modei}{k}(2,3)=C(pout+1,:) * Phi(:,ModeSel) * Psi(ModeSel,:) * B(:,pin+2);
-            ResidueAll{modei}{k}(3,1)=C(pout+2,:) * Phi(:,ModeSel) * Psi(ModeSel,:) * B(:,pin);
-            ResidueAll{modei}{k}(3,2)=C(pout+2,:) * Phi(:,ModeSel) * Psi(ModeSel,:) * B(:,pin+1); 
-            ResidueAll{modei}{k}(3,3)=C(pout+2,:) * Phi(:,ModeSel) * Psi(ModeSel,:) * B(:,pin+2); 
-
+            ResidueAll{modei}{k}=C(pout:pout+2,:) * Phi(:,ModeSel) * Psi(ModeSel,:) * B(:,pin:pin+2);
         else % Floating bus and passive load: not considered           
             ResidueAll{modei}{k} = [];
         end


### PR DESCRIPTION
Previously, calculation of IMR.IMRVal was incorrect, and has therefore been updated to reflect the correct definition. This issue was present in the master branch of SimplusGT but not in all branches.

Residue calculation in SSCal has also been updated to utilise the matrix format as previously suggested.